### PR TITLE
Store tokens in session table

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,7 +11,6 @@ import { headers, cookies } from "next/headers";
 import { nextCookies } from "better-auth/next-js";
 import Database from "better-sqlite3";
 
-
 const {
   IAM_API_URL,
   IAM_DASHBOARD_BASE_URL,
@@ -150,6 +149,28 @@ export const authConfig = (db: Database.Database) => {
           type: "boolean",
           defaultValue: false,
         },
+        accessToken: {
+          type: "string",
+          defaultValue: null,
+        },
+        refreshToken: {
+          type: "string",
+          defaultValue: null,
+        },
+        accessTokenExpiresAt: {
+          type: "date",
+          defaultValue: null,
+          required: false,
+        },
+        refreshTokenExpiresAt: {
+          type: "date",
+          defaultValue: null,
+          required: false,
+        },
+        scope: {
+          type: "string",
+          defaultValue: null,
+        },
       },
     },
     databaseHooks: {
@@ -163,14 +184,30 @@ export const authConfig = (db: Database.Database) => {
               await ctx.context.internalAdapter.findAccountByUserId(
                 sessionData.userId
               );
-            const { accessToken } = account;
+            const {
+              accessToken,
+              refreshToken,
+              accessTokenExpiresAt,
+              refreshTokenExpiresAt,
+              scope,
+            } = account;
             if (!accessToken) {
               throw new Error(
                 "failed to get user info: access token not found"
               );
             }
             const hasRoleAdmin = await fetchRoleAdmin(accessToken);
-            return { data: { ...sessionData, hasRoleAdmin } };
+            return {
+              data: {
+                ...sessionData,
+                hasRoleAdmin,
+                accessToken,
+                refreshToken,
+                accessTokenExpiresAt,
+                refreshTokenExpiresAt,
+                scope,
+              },
+            };
           },
         },
       },
@@ -208,12 +245,14 @@ export async function getSession(): Promise<Session | null> {
 }
 
 export async function getAccessToken() {
-  return await auth.api.getAccessToken({
-    body: {
-      providerId: "indigo-iam",
-    },
-    headers: await headers(),
-  });
+  const session = await getSession();
+  return {
+    accessToken: session?.session.accessToken,
+    refreshToken: session?.session.refreshToken,
+    accessTokenExpiresAt: session?.session.accessTokenExpiresAt,
+    refreshTokenExpiresAt: session?.session.refreshTokenExpiresAt,
+    scope: session?.session.scope,
+  };
 }
 
 /*
@@ -233,14 +272,15 @@ export async function updateAccessToken(scope: string) {
   if (account.refreshToken) {
     try {
       const tokens = await refreshAccessToken(account.refreshToken, scope);
-      await ctx.internalAdapter.updateAccount(account.id, {
+      console.log(session.session.id);
+      await ctx.internalAdapter.updateSession(session.session.token, {
         accessToken: tokens.accessToken,
         accessTokenExpiresAt: tokens.accessTokenExpiresAt,
         refreshToken: tokens.refreshToken,
         refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
         scope: tokens.scopes?.join(" "),
       });
-      console.debug("Refreshed access token.");
+      console.debug("Tokens updated successfully.");
       return tokens.accessToken;
     } catch (e: any) {
       console.error("Failed to refresh access token:", e);
@@ -251,8 +291,8 @@ export async function updateAccessToken(scope: string) {
 }
 
 export async function isUserAdmin() {
-  const { scopes } = await getAccessToken();
-  return scopes.join(" ").includes("iam:admin");
+  const { scope } = await getAccessToken();
+  return scope?.includes("iam:admin") ?? false;
 }
 
 export async function signIn() {

--- a/tests/auth.fixture.ts
+++ b/tests/auth.fixture.ts
@@ -5,29 +5,32 @@
 import { test as baseTest, expect, Page } from "@playwright/test";
 export { expect } from "@playwright/test";
 
-export const test = baseTest.extend({
-  page: async ({ page }, use) => {
-    test.slow();
-    await page.goto("./");
-    await page.locator("#username").fill("admin");
-    await page.locator("#password").fill("password");
-    await page.locator("#login-submit").click();
+async function login(page: Page) {
+  await page.goto("./");
+  await page.locator("#username").fill("admin");
+  await page.locator("#password").fill("password");
+  await page.locator("#login-submit").click();
+  await checkClientAuthorization(page);
 
-    // Check if client has to be authorized
-    await checkClientAuthorization(page);
+  // Redirect to new dashboard
+  await page.waitForURL("./users/me");
+  await expect(page.getByLabel("First Name")).toHaveValue("Admin");
+  await expect(page.getByLabel("Last Name")).toHaveValue("User");
+  await expect(page.getByLabel("Email")).toHaveValue("1_admin@iam.test");
+}
 
-    // Redirect to new dashboard
-    await page.waitForURL("./users/me");
-    await expect(page.getByLabel("First Name")).toHaveValue("Admin");
-    await expect(page.getByLabel("Last Name")).toHaveValue("User");
-    await expect(page.getByLabel("Email")).toHaveValue("1_admin@iam.test");
+async function logout(page: Page) {
+  await page.getByTestId("user-menu-btn").click();
+  await page.getByTestId("signout-btn").click();
+}
 
+export const test = baseTest.extend<{ page: Page }>({
+  page: async ({ browser }, use) => {
+    const newPage = await browser.newPage();
+    await login(newPage);
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    await use(page);
-
-    // Logout
-    await page.getByTestId("user-menu-btn").click();
-    await page.getByTestId("signout-btn").click();
+    await use(newPage);
+    await logout(newPage);
   },
 });
 

--- a/tests/groups.spec.ts
+++ b/tests/groups.spec.ts
@@ -15,18 +15,18 @@ function groupNameByIndex(index: number) {
 
 test("Create and delete group", async ({ page }) => {
   await test.step("add group", async () => {
+    await page.goto("./groups");
     // enable admin mode
     await page.getByTestId("user-menu-btn").click();
-    await page.getByText("Admin mode").click();
+    await page.getByRole("button", { name: "Admin mode" }).click();
     await expect(page.getByTestId("admin-mode-label")).toBeVisible();
 
-    await page.goto("./groups");
-    await page.getByTestId("add-group").click();
+    await page.getByRole("button", { name: "New group" }).click();
+    await expect(page.getByText("Create new group")).toBeVisible();
     // use hashes in order to have an exact 1 match from the search bar
     const groupName = groupNameByIndex(test.info().workerIndex);
-    const modal = page.getByTestId("modal");
-    await modal.locator("input[type=text]").fill(groupName);
-    await modal.locator("button[type=submit]").click();
+    await page.getByLabel("Group name").fill(groupName);
+    await page.getByRole("button", { name: "Add group" }).click();
     const toast = page.getByTestId("toast");
     await expect(toast).toBeVisible();
     await expect(toast.getByText("Group created")).toBeVisible();


### PR DESCRIPTION
Store access and refresh tokens in session table. This allows to have different scoped tokens for multiple browser sessions at the same time.

Closes https://github.com/indigo-iam/iam-dashboard/issues/93.