### PR TITLE
Hide linked apps and token tabs for admins

### DIFF
--- a/src/app/users/[user]/page.tsx
+++ b/src/app/users/[user]/page.tsx
@@ -53,8 +53,8 @@ export default async function UserPage(props: Readonly<UserPageProps>) {
           <Tab>GENERAL</Tab>
           <Tab>GROUPS</Tab>
           {!isMe && <Tab>CLIENTS</Tab>}
-          <Tab>APPS AND WEBSITES</Tab>
-          <Tab>ACTIVE TOKENS</Tab>
+          {isMe && <Tab>APPS AND WEBSITES</Tab>}
+          {isMe && <Tab>ACTIVE TOKENS</Tab>}
           <Tab>LINKED ACCOUNTS</Tab>
           <Tab>ATTRIBUTES</Tab>
         </TabList>

--- a/src/services/clients.ts
+++ b/src/services/clients.ts
@@ -89,7 +89,7 @@ export async function editClient(
     return {
       type: "success",
       title: "Client saved",
-      description: `Client '${client.client_name}'' has been modified`,
+      description: `Client '${client.client_name}' has been modified`,
     };
   }
   const { error } = await response.json();


### PR DESCRIPTION
The endpoint `/iam/api/approved` returns approved sites/applications only for the current user and there isn't the possibility for an admin to see approved sites or tokens for other users.
This PR hides those two tabs for users different from `/users/me`.