### PR TITLE
Separate ProgressBar from Loading

### DIFF
--- a/src/app/components/header/index.tsx
+++ b/src/app/components/header/index.tsx
@@ -5,7 +5,7 @@
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { ToggleDrawerButton } from "@/components/drawer/toggle-drawer-button";
 import Notifications from "@/components/notifications";
-import { ProgressBar } from "@/components/loading";
+import { ProgressBar } from "@/components/progress-bar";
 import { fetchMe } from "@/services/me";
 import { settings } from "@/config";
 import { UserPopover } from "./user-popover";

--- a/src/app/groups/[group]/components/group-info/add-label.tsx
+++ b/src/app/groups/[group]/components/group-info/add-label.tsx
@@ -14,6 +14,7 @@ import {
   ModalFooter,
   ModalProps,
 } from "@/components/modal";
+import { useProgressBar } from "@/components/progress-bar";
 import { toast } from "@/components/toaster";
 import { Group, GroupLabel } from "@/models/groups";
 import { addGroupLabel } from "@/services/groups";
@@ -28,6 +29,7 @@ interface AddLabelModalProps extends ModalProps {
 
 function AddLabelModal(props: Readonly<AddLabelModalProps>) {
   const { group, ...modalProps } = props;
+  const { startTransition } = useProgressBar();
 
   async function submit(event: React.SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -42,10 +44,14 @@ function AddLabelModal(props: Readonly<AddLabelModalProps>) {
     if (prefix) {
       gl = { ...gl, prefix };
     }
-    const res = await addGroupLabel(group.id, gl);
-    if (res.type !== "success") {
-      toast.toast(res);
-    }
+
+    startTransition(async () => {
+      console.log("label!")
+      const res = await addGroupLabel(group.id, gl);
+      if (res.type !== "success") {
+        toast.toast(res);
+      }
+    });
     modalProps.onClose();
   }
 

--- a/src/app/groups/[group]/components/group-info/label-view.tsx
+++ b/src/app/groups/[group]/components/group-info/label-view.tsx
@@ -4,6 +4,7 @@
 
 "use client";
 
+import { useProgressBar } from "@/components/progress-bar";
 import { toast } from "@/components/toaster";
 import { Group, GroupLabel } from "@/models/groups";
 import { deleteGroupLabel } from "@/services/groups";
@@ -16,13 +17,16 @@ type LabelProps = {
 
 export default function LabelView(props: Readonly<LabelProps>) {
   const { group, label } = props;
+  const { startTransition } = useProgressBar();
 
-  async function submit(event: React.SubmitEvent<HTMLFormElement>) {
+  function submit(event: React.SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
-    const res = await deleteGroupLabel(group.id, label);
-    if (res.type !== "success") {
-      toast.toast(res);
-    }
+    startTransition(async () => {
+      const res = await deleteGroupLabel(group.id, label);
+      if (res.type !== "success") {
+        toast.toast(res);
+      }
+    });
   }
   return (
     <form

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Header } from "@/app/components/header";
 import { Sidebar } from "@/app/components/sidebar";
 import { Toaster } from "@/components/toaster";
 import { LoadingProvider } from "@/components/loading";
+import { ProgressBarProvider } from "@/components/progress-bar";
 import "@/styles/main.css";
 
 export const metadata: Metadata = {
@@ -45,12 +46,14 @@ export default async function RootLayout(props: Readonly<RootLayoutProps>) {
         {/*this div is required by https://github.com/tailwindlabs/headlessui/issues/2752*/}
         <div>
           <LoadingProvider>
-            <Header hasRoleAdmin={hasRoleAdmin} isAdmin={isAdmin} />
-            <main>
-              <Sidebar hasRoleAdmin={hasRoleAdmin} isAdmin={isAdmin} />
-              <div className="content">{children}</div>
-            </main>
-            <Toaster />
+            <ProgressBarProvider>
+              <Header hasRoleAdmin={hasRoleAdmin} isAdmin={isAdmin} />
+              <main>
+                <Sidebar hasRoleAdmin={hasRoleAdmin} isAdmin={isAdmin} />
+                <div className="content">{children}</div>
+              </main>
+              <Toaster />
+            </ProgressBarProvider>
           </LoadingProvider>
         </div>
       </body>

--- a/src/app/users/[user]/components/attributes-labels/attributes/add-button/modal.tsx
+++ b/src/app/users/[user]/components/attributes-labels/attributes/add-button/modal.tsx
@@ -16,6 +16,7 @@ import {
   ModalFooter,
   ModalProps,
 } from "@/components/modal";
+import { useProgressBar } from "@/components/progress-bar";
 import { toast } from "@/components/toaster";
 import { addAttribute } from "@/services/users";
 
@@ -76,6 +77,7 @@ export default function AddAttributeModal(
   props: Readonly<AddAttributeModalProps>
 ) {
   const { userId, show, onClose } = props;
+  const { startTransition } = useProgressBar();
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
   const formRef = useRef<HTMLFormElement>(null);
@@ -97,13 +99,15 @@ export default function AddAttributeModal(
     }, 300);
   }
 
-  async function submit(event: React.SubmitEvent<HTMLFormElement>) {
+  function submit(event: React.SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const name = formData.get("attr-name") as string;
     const value = formData.get("attr-value") as string;
-    const res = await addAttribute(userId, { name, value });
-    toast.toast(res);
+    startTransition(async () => {
+      const res = await addAttribute(userId, { name, value });
+      toast.toast(res);
+    });
     closeAndReset();
   }
 

--- a/src/app/users/[user]/components/attributes-labels/attributes/attribute-view.tsx
+++ b/src/app/users/[user]/components/attributes-labels/attributes/attribute-view.tsx
@@ -9,6 +9,7 @@
 "use client";
 
 import BaseLabelView from "@/components/badges/label-view";
+import { useProgressBar } from "@/components/progress-bar";
 import { toast } from "@/components/toaster";
 import { Attribute } from "@/models/attributes";
 import { deleteAttribute } from "@/services/users";
@@ -21,11 +22,14 @@ type AttributeViewProps = {
 
 export function AttributeView(props: Readonly<AttributeViewProps>) {
   const { isAdmin, userId, attr } = props;
-  async function deleteLabel() {
-    const res = await deleteAttribute(userId, attr);
-    if (res) {
-      toast.toast(res);
-    }
+  const { startTransition } = useProgressBar();
+  function deleteLabel() {
+    startTransition(async () => {
+      const res = await deleteAttribute(userId, attr);
+      if (res) {
+        toast.toast(res);
+      }
+    });
   }
   return (
     <BaseLabelView

--- a/src/app/users/[user]/components/attributes-labels/labels/add-button.tsx
+++ b/src/app/users/[user]/components/attributes-labels/labels/add-button.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/modal";
 import { toast } from "@/components/toaster";
 import { addUserLabel } from "@/services/users";
+import { useProgressBar } from "@/components/progress-bar";
 
 type ValidatePrefixViewProps = {
   prefix: string;
@@ -101,6 +102,7 @@ type AddLabelModalProps = ModalProps & {
 function AddLabelModal(props: Readonly<AddLabelModalProps>) {
   const { userId, show, onClose } = props;
   const formRef = useRef<HTMLFormElement>(null);
+  const { startTransition } = useProgressBar();
   const [prefix, setPrefix] = useState("");
   const [name, setName] = useState("");
   const [value, setValue] = useState<string | null>(null);
@@ -115,10 +117,12 @@ function AddLabelModal(props: Readonly<AddLabelModalProps>) {
     const prefix = (formData.get("prefix") as string | null) ?? "";
     const name = (formData.get("name") as string | null) ?? "";
     const value = formData.get("value") as string | null;
-    const res = await addUserLabel(userId, prefix, name, value);
-    if (res) {
-      toast.toast(res);
-    }
+    startTransition(async () => {
+      const res = await addUserLabel(userId, prefix, name, value);
+      if (res) {
+        toast.toast(res);
+      }
+    });
     onClose();
   }
 

--- a/src/app/users/[user]/components/attributes-labels/labels/label-view.tsx
+++ b/src/app/users/[user]/components/attributes-labels/labels/label-view.tsx
@@ -7,6 +7,7 @@
 import BaseLabelView from "@/components/badges/label-view";
 import { deleteUserLabel } from "@/services/users";
 import { toast } from "@/components/toaster";
+import { useProgressBar } from "@/components/progress-bar";
 
 type LabelViewProps = {
   isAdmin: boolean;
@@ -18,11 +19,14 @@ type LabelViewProps = {
 
 export function LabelView(props: Readonly<LabelViewProps>) {
   const { isAdmin, userId, prefix, name, value } = props;
+  const { startTransition } = useProgressBar();
   async function deleteLabel() {
-    const res = await deleteUserLabel(userId, prefix, name);
-    if (res) {
-      toast.toast(res);
-    }
+    startTransition(async () => {
+      const res = await deleteUserLabel(userId, prefix, name);
+      if (res) {
+        toast.toast(res);
+      }
+    });
   }
   return (
     <BaseLabelView

--- a/src/app/users/[user]/components/general/danger-zone/index.tsx
+++ b/src/app/users/[user]/components/general/danger-zone/index.tsx
@@ -42,7 +42,7 @@ export function DangerZone(props: Readonly<DangerZoneProps>) {
           <p className="whitespace-normal">
             A disabled user cannot login and tokens are immediately revoked.
           </p>
-          <p>Delete the user to completely remove them from he organization.</p>
+          <p>Delete the user to completely remove them from the organization.</p>
         </div>
       </div>
       <div className="w-full space-y-4 lg:w-2/3">

--- a/src/components/drawer/link.tsx
+++ b/src/components/drawer/link.tsx
@@ -8,7 +8,7 @@ import { default as NextLink } from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 
 import { toggleDrawer } from "./drawer";
-import { useLoading } from "../loading";
+import { useProgressBar } from "../progress-bar";
 
 export type LinkProps = {
   title: string;
@@ -20,7 +20,7 @@ export function Link(props: Readonly<LinkProps>) {
   const { title, href, children } = props;
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { startProgressBar } = useLoading();
+  const { startProgressBar } = useProgressBar();
 
   let selected = false;
   switch (pathname) {

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import NextLink from "next/link";
-import { useLoading } from "../loading";
+import { useProgressBar } from "../progress-bar";
 
 type LinkProps = {
   href: string;
@@ -15,7 +15,7 @@ type LinkProps = {
 } & { [key: `data-${string}`]: unknown };
 
 export default function Link(props: Readonly<LinkProps>) {
-  const { startProgressBar } = useLoading();
+  const { startProgressBar } = useProgressBar();
   const { href, className, title, children, ...others } = props;
   return (
     <NextLink

--- a/src/components/loading/context.ts
+++ b/src/components/loading/context.ts
@@ -8,10 +8,6 @@ import { createContext, useContext } from "react";
 
 type LoadingContextProps = {
   startLoadingTransition: (callback: () => Promise<void>) => void;
-  startProgressBar: () => Promise<void>;
-  stopProgressBar: () => void;
-  isProgressBarHidden: boolean;
-  progress: number;
 };
 
 export const LoadingContext = createContext<LoadingContextProps | null>(null);

--- a/src/components/loading/index.tsx
+++ b/src/components/loading/index.tsx
@@ -4,5 +4,4 @@
 
 export { useLoading } from "./context";
 export { LoadingProvider } from "./provider";
-export { ProgressBar } from "./progress-bar";
 export { LoadingList } from "./loading-list";

--- a/src/components/loading/provider.tsx
+++ b/src/components/loading/provider.tsx
@@ -4,16 +4,8 @@
 
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
 import { LoadingContext } from "./context";
-
-// the amount of time to wait before incrementing the progress bar
-const TRICKLE_DURATION = 200;
-
-function clamp(x: number, a: number, b: number) {
-  return Math.min(Math.max(x, a), b);
-}
 
 type LoadingProviderProps = {
   children: React.ReactNode;
@@ -22,14 +14,6 @@ type LoadingProviderProps = {
 export function LoadingProvider(props: Readonly<LoadingProviderProps>) {
   const { children } = props;
   const [isPending, startTransition] = useTransition();
-  const [progress, setProgress] = useState(0);
-  const [isProgressBarHidden, setIsProgressBarHidden] = useState(false);
-  const pathname = usePathname();
-  const searchParams = useSearchParams().toString();
-  const progressRef = useRef(0);
-  const timerRef = useRef<ReturnType<typeof setInterval>>(null);
-  const path = searchParams ? `${pathname}?${searchParams}` : pathname;
-  const prevPath = useRef("");
 
   async function startLoadingTransition(callback: () => Promise<void>) {
     startTransition(async () => {
@@ -37,63 +21,10 @@ export function LoadingProvider(props: Readonly<LoadingProviderProps>) {
     });
   }
 
-  function trickle() {
-    if (progressRef.current < 1) {
-      increment();
-    }
-  }
-
-  async function startProgressBar() {
-    progressRef.current = 0;
-    timerRef.current = setInterval(trickle, TRICKLE_DURATION);
-    setIsProgressBarHidden(false);
-  }
-
-  async function stopProgressBar() {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-    }
-    setProgress(1);
-    setTimeout(() => {
-      setIsProgressBarHidden(true);
-      setProgress(0);
-    }, TRICKLE_DURATION);
-  }
-
-  function increment() {
-    let amount = 0;
-    const n = progressRef.current;
-    if (n >= 0 && n < 0.2) {
-      amount = 0.1;
-    } else if (n >= 0.2 && n < 0.5) {
-      amount = 0.04;
-    } else if (n >= 0.5 && n < 0.8) {
-      amount = 0.02;
-    } else if (n >= 0.8 && n < 0.99) {
-      amount = 0.005;
-    } else {
-      amount = 0;
-    }
-    progressRef.current = clamp(n + amount, 0, 1);
-    setProgress(progressRef.current);
-  }
-
-  useEffect(() => {
-    if (prevPath.current === path) {
-      return;
-    }
-    stopProgressBar();
-    prevPath.current = path;
-  }, [path]);
-
   return (
     <LoadingContext
       value={{
         startLoadingTransition,
-        startProgressBar,
-        stopProgressBar,
-        isProgressBarHidden,
-        progress,
       }}
     >
       {isPending && <Loading />}

--- a/src/components/paginator/index.tsx
+++ b/src/components/paginator/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@heroicons/react/24/outline";
 import Link from "@/components/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useLoading } from "../loading";
+import { useProgressBar } from "../progress-bar";
 
 const className =
   "flex p-0.5 ml-0 bg-white text-gray-500 border  hover:bg-gray-200 dark:bg-secondary/50 first:rounded-l-lg last:rounded-r-lg data-[disabled=true]:opacity-30 data-[disabled=true]:pointer-events-none hover:text-gray-500 dark:bg-gray-700  dark:text-gray-500 dark:hover:bg-gray-600 dark:hover:text-gray-400";
@@ -26,7 +26,7 @@ export default function Paginator(props: Readonly<PaginatorProps>) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { startProgressBar } = useLoading();
+  const { startProgressBar } = useProgressBar();
   const currentPage = Number(searchParams.get("page")) || 1;
   const itemsPerPage = Number(searchParams.get("count")) || 10;
 

--- a/src/components/progress-bar/context.ts
+++ b/src/components/progress-bar/context.ts
@@ -7,7 +7,7 @@
 import { createContext, useContext } from "react";
 
 type ProgressBarContextProps = {
-  startLoadingTransition: (callback: () => Promise<void>) => void;
+  startTransition: (callback: () => Promise<void>) => void;
   startProgressBar: () => Promise<void>;
   stopProgressBar: () => void;
   isProgressBarHidden: boolean;

--- a/src/components/progress-bar/context.ts
+++ b/src/components/progress-bar/context.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Istituto Nazionale di Fisica Nucleare
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+"use client";
+
+import { createContext, useContext } from "react";
+
+type ProgressBarContextProps = {
+  startLoadingTransition: (callback: () => Promise<void>) => void;
+  startProgressBar: () => Promise<void>;
+  stopProgressBar: () => void;
+  isProgressBarHidden: boolean;
+  progress: number;
+};
+
+export const ProgressBarContext = createContext<ProgressBarContextProps | null>(
+  null
+);
+
+export function useProgressBar() {
+  const context = useContext(ProgressBarContext);
+  if (!context) {
+    throw new Error(
+      "ProgressBarContext is undefined, please verify you are calling 'useLoading' inside a child of ProgressBarContext component."
+    );
+  }
+  return context;
+}

--- a/src/components/progress-bar/index.ts
+++ b/src/components/progress-bar/index.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Istituto Nazionale di Fisica Nucleare
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+export { useProgressBar } from "./context";
+export { ProgressBarProvider } from "./provider";
+export { ProgressBar } from "./progress-bar";

--- a/src/components/progress-bar/progress-bar.tsx
+++ b/src/components/progress-bar/progress-bar.tsx
@@ -4,10 +4,10 @@
 
 "use client";
 
-import { useLoading } from "./context";
+import { useProgressBar } from "./context";
 
 export function ProgressBar() {
-  const { progress, isProgressBarHidden } = useLoading();
+  const { progress, isProgressBarHidden } = useProgressBar();
   const progressPercentage = `${Math.round(progress * 100)}%`;
   return (
     <div

--- a/src/components/progress-bar/provider.tsx
+++ b/src/components/progress-bar/provider.tsx
@@ -22,7 +22,6 @@ type ProgressBarProviderProps = {
 
 export function ProgressBarProvider(props: Readonly<ProgressBarProviderProps>) {
   const { children } = props;
-  const [isPending, startTransition] = useTransition();
   const [progress, setProgress] = useState(0);
   const [isProgressBarHidden, setIsProgressBarHidden] = useState(false);
   const pathname = usePathname();
@@ -32,10 +31,10 @@ export function ProgressBarProvider(props: Readonly<ProgressBarProviderProps>) {
   const path = searchParams ? `${pathname}?${searchParams}` : pathname;
   const prevPath = useRef("");
 
-  async function startLoadingTransition(callback: () => Promise<void>) {
-    startTransition(async () => {
-      await callback();
-    });
+  async function startTransition(callback: () => Promise<void>) {
+    startProgressBar();
+    await callback();
+    stopProgressBar();
   }
 
   function trickle() {
@@ -86,18 +85,16 @@ export function ProgressBarProvider(props: Readonly<ProgressBarProviderProps>) {
     stopProgressBar();
     prevPath.current = path;
   }, [path]);
-
   return (
     <ProgressBarContext
       value={{
-        startLoadingTransition,
+        startTransition,
         startProgressBar,
         stopProgressBar,
         isProgressBarHidden,
         progress,
       }}
     >
-      {isPending && <ProgressBar />}
       {children}
     </ProgressBarContext>
   );

--- a/src/components/progress-bar/provider.tsx
+++ b/src/components/progress-bar/provider.tsx
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Istituto Nazionale di Fisica Nucleare
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { ProgressBarContext } from "./context";
+import { ProgressBar } from "./progress-bar";
+
+// the amount of time to wait before incrementing the progress bar
+const TRICKLE_DURATION = 200;
+
+function clamp(x: number, a: number, b: number) {
+  return Math.min(Math.max(x, a), b);
+}
+
+type ProgressBarProviderProps = {
+  children: React.ReactNode;
+};
+
+export function ProgressBarProvider(props: Readonly<ProgressBarProviderProps>) {
+  const { children } = props;
+  const [isPending, startTransition] = useTransition();
+  const [progress, setProgress] = useState(0);
+  const [isProgressBarHidden, setIsProgressBarHidden] = useState(false);
+  const pathname = usePathname();
+  const searchParams = useSearchParams().toString();
+  const progressRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setInterval>>(null);
+  const path = searchParams ? `${pathname}?${searchParams}` : pathname;
+  const prevPath = useRef("");
+
+  async function startLoadingTransition(callback: () => Promise<void>) {
+    startTransition(async () => {
+      await callback();
+    });
+  }
+
+  function trickle() {
+    if (progressRef.current < 1) {
+      increment();
+    }
+  }
+
+  async function startProgressBar() {
+    progressRef.current = 0;
+    timerRef.current = setInterval(trickle, TRICKLE_DURATION);
+    setIsProgressBarHidden(false);
+  }
+
+  async function stopProgressBar() {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+    }
+    setProgress(1);
+    setTimeout(() => {
+      setIsProgressBarHidden(true);
+      setProgress(0);
+    }, TRICKLE_DURATION);
+  }
+
+  function increment() {
+    let amount = 0;
+    const n = progressRef.current;
+    if (n >= 0 && n < 0.2) {
+      amount = 0.1;
+    } else if (n >= 0.2 && n < 0.5) {
+      amount = 0.04;
+    } else if (n >= 0.5 && n < 0.8) {
+      amount = 0.02;
+    } else if (n >= 0.8 && n < 0.99) {
+      amount = 0.005;
+    } else {
+      amount = 0;
+    }
+    progressRef.current = clamp(n + amount, 0, 1);
+    setProgress(progressRef.current);
+  }
+
+  useEffect(() => {
+    if (prevPath.current === path) {
+      return;
+    }
+    stopProgressBar();
+    prevPath.current = path;
+  }, [path]);
+
+  return (
+    <ProgressBarContext
+      value={{
+        startLoadingTransition,
+        startProgressBar,
+        stopProgressBar,
+        isProgressBarHidden,
+        progress,
+      }}
+    >
+      {isPending && <ProgressBar />}
+      {children}
+    </ProgressBarContext>
+  );
+}


### PR DESCRIPTION
Move ProgressBar to a separated component for better management.
Add a `startTransition` function that mimic the original react behavior.