### PR TITLE
Fix login service IAM_ISSUER env variable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       IAM_PORT: 8080
       IAM_HOST: iam.test.example
       IAM_BASE_URL: https://iam.test.example
-      IAM_ISSUER: https://iam.test.example
+      IAM_ISSUER: https://iam.test.example/
       IAM_REGISTRATION_OIDC_ISSUER: https://iam.test.example
       IAM_REGISTRATION_AUTHENTICATION_TYPE: oidc
       IAM_ACCESS_TOKEN_INCLUDE_SCOPE: true


### PR DESCRIPTION
Since commit https://github.com/indigo-iam/iam/commit/47c5aa9d892b9e7f98eba2ad3b460f4829ac2a18 a trailing '/' is required for the variable IAM_ISSUER