### PR TITLE
Mitigate hydration issues during tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           docker compose up -d
 
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npx playwright test --reporter=list
 
       - name: Cleanup test environment
         run: docker compose down --remove-orphans --volumes

--- a/src/app/components/header/user-popover.tsx
+++ b/src/app/components/header/user-popover.tsx
@@ -10,6 +10,7 @@ import { Gravatar } from "@/components/gravatar";
 import { AdminModeButton, UserModeButton } from "./admin-user-buttons";
 import { SignoutButton } from "./signout-button";
 import { User } from "@/models/scim";
+import { useDisabled } from "@/utils/hooks";
 
 type UserPopoverProps = {
   hasRoleAdmin?: boolean;
@@ -19,6 +20,7 @@ type UserPopoverProps = {
 
 export function UserPopover(props: Readonly<UserPopoverProps>) {
   const { hasRoleAdmin, isAdmin, user } = props;
+  const disabled = useDisabled();
   const email = user.emails?.[0].value;
 
   return (
@@ -27,6 +29,7 @@ export function UserPopover(props: Readonly<UserPopoverProps>) {
         className="hover:cursor-pointer"
         title="Open user menu"
         data-testid="user-menu-btn"
+        disabled={disabled}
       >
         <Gravatar email={email} />
       </PopoverButton>

--- a/src/components/buttons/index.ts
+++ b/src/components/buttons/index.ts
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2025 Istituto Nazionale di Fisica Nucleare
-//
-// SPDX-License-Identifier: EUPL-1.2
-
-export { Button } from "@headlessui/react";

--- a/src/components/buttons/index.tsx
+++ b/src/components/buttons/index.tsx
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Istituto Nazionale di Fisica Nucleare
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+"use client";
+
+import { useDisabled } from "@/utils/hooks";
+import { Button as HeadlessButton, ButtonProps } from "@headlessui/react";
+
+export function Button(props: Readonly<ButtonProps>) {
+  const disabled = useDisabled();
+
+  return <HeadlessButton {...props} disabled={disabled || props.disabled} />;
+}

--- a/src/components/toaster/index.tsx
+++ b/src/components/toaster/index.tsx
@@ -13,6 +13,7 @@ import {
   InformationCircleIcon,
   XCircleIcon,
 } from "@heroicons/react/24/outline";
+import { useDisabled } from "@/utils/hooks";
 
 const breakpoints = {
   sm: 640,
@@ -120,6 +121,7 @@ type ToastProps = {
 
 function Toast(props: Readonly<ToastProps>) {
   const { title, description, type } = props;
+  const disabled = useDisabled();
   return (
     <div
       className="overlay flex w-full items-center border px-3 py-2"
@@ -139,6 +141,7 @@ function Toast(props: Readonly<ToastProps>) {
       </div>
       <button
         title="Close"
+        disabled={disabled}
         className="w-8 flex-none cursor-pointer rounded-full p-1.25 text-gray-500 hover:bg-gray-300 dark:text-gray-200 dark:hover:bg-gray-500"
         onClick={() => {
           sonnerToast.dismiss(props.id);

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -40,3 +40,16 @@ export function useDeferredCallback() {
     deferredCallback,
   };
 }
+
+export function useDisabled() {
+  const [disabled, setDisabled] = useState(true);
+
+  useEffect(() => {
+    const f = async () => {
+      setDisabled(false);
+    };
+    f();
+  }, []);
+
+  return disabled;
+}

--- a/tests/auth/auth.spec.ts
+++ b/tests/auth/auth.spec.ts
@@ -72,7 +72,7 @@ testAdmin(
     await testAdmin.step("login", async () => {
       await page.goto("./");
       await expect(
-        page.getByLabel("Username").locator("visible=true")
+        page.getByLabel("Username").filter({ visible: true })
       ).toHaveValue("admin");
     });
 
@@ -205,13 +205,14 @@ testUser("User cannot enable admin mode", async ({ signedUpPage }) => {
   await testUser.step("login", async () => {
     await signedUpPage.goto("./");
     await expect(
-      signedUpPage.getByLabel("Username").locator("visible=true")
+      signedUpPage.getByLabel("Username").filter({ visible: true })
     ).toHaveValue("test");
   });
 
   await testUser.step("try enabling admin mode", async () => {
     const userMenuBtn = signedUpPage.getByTestId("user-menu-btn");
     await expect(userMenuBtn).toBeVisible();
+    await expect(userMenuBtn).toBeEnabled();
     await userMenuBtn.click();
     const userMenu = signedUpPage.getByTestId("user-menu");
     await expect(userMenu).toBeVisible();

--- a/tests/auth/fixture.ts
+++ b/tests/auth/fixture.ts
@@ -32,11 +32,9 @@ export const TEST_USER: UserInfo = {
 async function openUserMenu(page: Page) {
   const userMenuButton = page.getByTitle("Open user menu");
   const userMenu = page.getByTestId("user-menu");
-  await expect(async () => {
-    await expect(userMenuButton).toBeEnabled();
-    await userMenuButton.click();
-    await expect(userMenu).toBeVisible();
-  }).toPass();
+  await expect(userMenuButton).toBeEnabled();
+  await userMenuButton.click();
+  await expect(userMenu).toBeVisible();
   return userMenu;
 }
 

--- a/tests/groups/groups.spec.ts
+++ b/tests/groups/groups.spec.ts
@@ -1,5 +1,6 @@
 import { testAdmin, expect, enableAdminMode, testUser } from "../auth/fixture";
 import crypto from "node:crypto";
+import { dismissToast } from "../utils";
 
 function sha256(s: string) {
   const hash = crypto.createHash("sha256");
@@ -23,7 +24,10 @@ testAdmin("Admin can create and delete a group", async ({ signedUpPage }) => {
     await enableAdminMode(page);
     const heading = page.getByRole("heading", { name: "Groups" });
     await expect(heading).toBeVisible();
-    await page.getByRole("button", { name: "New group" }).click();
+    const newGroupBtn = page.getByRole("button", { name: "New group" });
+    await expect(newGroupBtn).toBeVisible();
+    await expect(newGroupBtn).toBeEnabled();
+    await newGroupBtn.click();
     await expect(page.getByText("Create new group")).toBeVisible();
     // use hashes in order to have an exact 1 match from the search bar
     const groupName = groupNameByIndex(testAdmin.info().workerIndex);
@@ -36,6 +40,7 @@ testAdmin("Admin can create and delete a group", async ({ signedUpPage }) => {
     await page.goto("./groups");
     await page
       .getByTestId("search-group")
+      .filter({ visible: true })
       .pressSequentially(groupName, { delay: 30 });
     const options = page.getByTitle("More");
     await expect(options).toHaveCount(1);
@@ -50,6 +55,7 @@ testAdmin("Admin can create and delete a group", async ({ signedUpPage }) => {
     const groupName = groupNameByIndex(testAdmin.info().workerIndex);
     await page
       .getByTestId("search-group")
+      .filter({ visible: true })
       .pressSequentially(groupName, { delay: 30 });
     const options = page.getByTitle("More");
     await expect(options).toHaveCount(1);
@@ -57,18 +63,17 @@ testAdmin("Admin can create and delete a group", async ({ signedUpPage }) => {
     await options.click();
     const deleteOption = page.getByTestId("delete-group-opt");
     await expect(deleteOption).toBeVisible();
+    await expect(deleteOption).toBeEnabled();
     await deleteOption.click();
     await page
       .getByRole("button", { name: "Delete", exact: true })
       .click({ delay: 300 });
-    const toast = page.getByTestId("toast").first();
-    await expect(toast).toBeVisible();
-    await expect(toast.getByText("Group deleted")).toBeVisible();
-    await toast.getByTitle("Close").click();
+    await dismissToast(page, "Group delete", "success");
     // check group has been deleted
     await page.getByTitle("Clear search").click();
     await page
       .getByTestId("search-group")
+      .filter({ visible: true })
       .pressSequentially(groupName, { delay: 30 });
     await expect(page.getByTitle("More")).toHaveCount(0);
     expect(page.getByText("No group found.").isVisible());

--- a/tests/users/user.spec.ts
+++ b/tests/users/user.spec.ts
@@ -57,16 +57,14 @@ test("User can send a request to join a group", async ({ page }) => {
       .getByRole("listitem")
       .filter({ hasText: "Motivation: Test motivation message" });
     const more = item.getByRole("button", { name: "More" });
+    await expect(more).toBeEnabled();
+    await more.click();
     const revokeOption = page.getByRole("button", { name: "Revoke request" });
-    await expect(async () => {
-      await more.click();
-      await expect(revokeOption).toBeVisible();
-    }).toPass();
+    await expect(revokeOption).toBeVisible();
+    await expect(revokeOption).toBeEnabled();
+    await revokeOption.click();
     const dialog = page.getByRole("dialog").filter({ visible: true });
-    await expect(async () => {
-      await revokeOption.click();
-      await expect(dialog).toBeVisible();
-    }).toPass();
+    await expect(dialog).toBeVisible();
     await dialog.getByRole("button", { name: "Revoke request" }).click();
     const pendingRequests = page.getByText("Pending requests");
     await expect(pendingRequests).toBeHidden();

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,15 +6,14 @@ import { ToastTypes } from "@/components/toaster";
 import { expect, Locator, Page } from "@playwright/test";
 
 export async function changeTabPanel(button: Locator) {
-  await expect(async () => {
-    await expect(button).toBeVisible();
-    await expect(button).toHaveAttribute(
-      "aria-controls",
-      /headlessui-tabs-panel-.*/
-    );
-    await button.click();
-    await expect(button).toHaveAttribute("data-selected", "");
-  }).toPass();
+  await expect(button).toBeVisible();
+  await expect(button).toBeEnabled();
+  await expect(button).toHaveAttribute(
+    "aria-controls",
+    /headlessui-tabs-panel-.*/
+  );
+  await button.click();
+  await expect(button).toHaveAttribute("data-selected", "");
 }
 
 export async function dismissToast(

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -28,6 +28,7 @@ export async function dismissToast(
   await expect(toast).toHaveCount(1);
   await expect(toast).toHaveAttribute("data-toast-type", type);
   const closeButton = toast.getByTitle("Close");
+  await expect(closeButton).toBeEnabled();
   await closeButton.click();
   await expect(toast).toBeHidden();
 }


### PR DESCRIPTION
Several tests result flaky because Playwright may click too fast on buttons before components are fully loaded on the DOM. Add useDisabled react hook to preventively disabled buttons until loading completes.