### PR TITLE
Disable telemetry data by default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -74,10 +74,7 @@ function loadOidcAdminScopes() {
 }
 
 function loadOtelExporterOtlpEndpoint() {
-  return loadEnvVariable(
-    "IAM_OTEL_EXPORTER_OTLP_ENDPOINT",
-    "https://otello.cloud.cnaf.infn.it:8443/collector/v1/traces"
-  );
+  return loadOptionalUrlFromEnv("IAM_DASHBOARD_OTEL_EXPORTER_OTLP_ENDPOINT");
 }
 
 function loadOrganizationName() {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -37,6 +37,9 @@ declare global {
 }
 
 function setupOtel() {
+  if (!IAM_DASHBOARD_OTEL_EXPORTER_OTLP_ENDPOINT) {
+    return;
+  }
   registerOTel({
     serviceName: "iam-dashboard",
     traceExporter: new OTLPHttpJsonTraceExporter({
@@ -49,6 +52,9 @@ function setupOtel() {
       "host.name": new URL(IAM_DASHBOARD_BASE_URL).hostname,
     },
   });
+  console.log(
+    `Telemetry enabled, data will be sent to ${IAM_DASHBOARD_OTEL_EXPORTER_OTLP_ENDPOINT}`
+  );
 }
 
 async function setupAuthDb() {


### PR DESCRIPTION
Telemetry (otello) is now disabled by default. To enable telemetry set the variable `IAM_DASHBOARD_OTEL_EXPORTER_OTLP_ENDPOINT`.